### PR TITLE
[api] add page length and tip hash

### DIFF
--- a/lib/status.js
+++ b/lib/status.js
@@ -117,6 +117,7 @@ StatusController.prototype.sync = function(req, res) {
         blockChainHeight: self.node.services.bitcoind.height,
         syncPercentage: Math.round(percentage),
         height: self.node.services.bitcoind.height,
+        hash: this.node.services.db.tip.hash,
         error: null,
         type: 'bitcore node'
       };

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -219,7 +219,8 @@ TxController.prototype.list = function(req, res) {
   var blockHash = req.query.block;
   var address = req.query.address;
   var page = parseInt(req.query.pageNum) || 0;
-  var pageLength = 10;
+  var pageLength = parseInt(req.query.pageSize) || 10;
+  pageLength = pageLength > 100 ? 100: pageLength; // Untested limit of 100 transactions.
   var pagesTotal = 1;
 
   if(blockHash) {


### PR DESCRIPTION
Simple API changes for better blockchain parsing. Allow
for page length definition on block transactions, as well
as tip hash in sync status.